### PR TITLE
Fix config to play by the rules of Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ module.exports = {
     'declaration-block-semicolon-space-before': 'never',
     'declaration-block-single-line-max-declarations': 1,
     'declaration-block-trailing-semicolon': 'always',
-    'declaration-colon-newline-after': 'always-multi-line',
     'declaration-colon-space-after': 'always-single-line',
     'declaration-colon-space-before': 'never',
     'declaration-property-value-blacklist': {'/^border/': ['none']},


### PR DESCRIPTION
Since we use Prettier in our projects, we need to remove this rule because it conflicts with the formatting Prettier does when a line exceeds 80 characters.

Example:

```scss
// What Prettier does
background: #2f3235 url('/assets/images/img-background-menu.jpg') center
    no-repeat;

// What Stylelint wants
background:
  #2f3235 url('/assets/images/img-background-menu.jpg') center no-repeat;