### PR TITLE
Add the @use keyword to the unknown list

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   rules: {
     'at-rule-no-unknown': [
       true,
-      {ignoreAtRules: ['mixin', 'content', 'include']},
+      {ignoreAtRules: ['mixin', 'content', 'include', 'use']},
     ],
     'at-rule-no-vendor-prefix': true,
     'block-no-empty': true,


### PR DESCRIPTION
The @use keyword is the new recommended way by the SAAS team to import Sass and CSS stylesheets.
Source: https://sass-lang.com/documentation/at-rules/import/

However, it is currently unrecognized and throws an error. This PR adds the keyword to the ignoreAtRules list.